### PR TITLE
Re-add with-shaded-core artifact to build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,38 @@ under the License.
         <groupId>org.eluder.coveralls</groupId>
         <artifactId>coveralls-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.datasketches:datasketches-java</include>
+                  <include>org.apache.datasketches:datasketches-memory</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>org.apache.datasketches</pattern>
+                  <shadedPattern>shaded.org.apache.datasketches</shadedPattern>
+                  <excludes>
+                    <exclude>org.apache.datasketches.hive.**</exclude>
+                  </excludes>
+                </relocation>
+              </relocations>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>with-shaded-core</shadedClassifierName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
The commit caf38c46381cb4643cc2e084dbc6669322796e3c have removed the shaded-core artifact - I'm not sure if that was intentional; because there were pretty big changes in that commit.

Because the website references it in almost all Hive examples:I think it might be better to add it back.