### PR TITLE
Fix theta sketch estimation if input has extra bytes

### DIFF
--- a/src/main/java/org/apache/datasketches/hive/theta/EstimateSketchUDF.java
+++ b/src/main/java/org/apache/datasketches/hive/theta/EstimateSketchUDF.java
@@ -56,7 +56,8 @@ public class EstimateSketchUDF extends UDF {
       return 0.0;
     }
 
-    final byte[] serializedSketch = binarySketch.getBytes();
+    final byte[] serializedSketch = new byte[binarySketch.getLength()];
+    System.arraycopy(binarySketch.getBytes(), 0, serializedSketch, 0, binarySketch.getLength());
 
     if (serializedSketch.length <= EMPTY_SKETCH_SIZE_BYTES) {
       return 0.0;

--- a/src/test/java/org/apache/datasketches/hive/theta/EstimateSketchUDFTest.java
+++ b/src/test/java/org/apache/datasketches/hive/theta/EstimateSketchUDFTest.java
@@ -97,4 +97,24 @@ public class EstimateSketchUDFTest {
     assertEquals(128.0, testResult);
   }
 
+  @Test
+  public void evaluateRespectsByteLength() {
+    // In some instances, the BytesWritable buffer returned by getBytes() might be larger than the actual sketch bytes.
+    // getLength() should give the correct length to use.
+    //
+    // https://github.com/apache/incubator-datasketches-hive/issues/50
+
+    byte[] inputBytes = new byte[]{
+            (byte) 0x01, (byte) 0x03, (byte) 0x03, (byte) 0x00,
+            (byte) 0x00, (byte) 0x3a, (byte) 0xcc, (byte) 0x93,
+            (byte) 0x15, (byte) 0xf9, (byte) 0x7d, (byte) 0xcb,
+            (byte) 0xbd, (byte) 0x86, (byte) 0xa1, (byte) 0x05,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00
+    };
+    BytesWritable input = new BytesWritable(inputBytes, 16);
+    EstimateSketchUDF estimate = new EstimateSketchUDF();
+    Double testResult = estimate.evaluate(input);
+    assertEquals(1.0, testResult, 0.0);
+  }
 }


### PR DESCRIPTION
In some cases, the bytes in BytesWritable will contain some extra space, but
getLength will give the right amount of bytes to read.

Fixes #50 